### PR TITLE
Support both python2 and python3

### DIFF
--- a/pythonToMarkdown/markdownwriter/__init__.py
+++ b/pythonToMarkdown/markdownwriter/__init__.py
@@ -1,2 +1,5 @@
 # outer __init__.py
-from MarkdownWriter import *
+try:  # python2
+    from MarkdownWriter import *
+except ImportError:  # python3
+    pass


### PR DESCRIPTION
When using this library installed with pip on python 3.4, the following error occurs:

```
Traceback (most recent call last):
  File "env/lib/python3.4/site-packages/markdownwriter/__init__.py", line 2, in <module>
    from MarkdownWriter import *
ImportError: No module named 'MarkdownWriter'
```
